### PR TITLE
Improve handling of custom force field

### DIFF
--- a/docs/source/modules/system_builder.rst
+++ b/docs/source/modules/system_builder.rst
@@ -1,0 +1,6 @@
+System Bilder
+=============
+
+.. automodule:: abfe.preparation.system_builder
+    :members:
+    :special-members: __init__, __call__

--- a/src/abfe/preparation/solvent.py
+++ b/src/abfe/preparation/solvent.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 import os
 import shutil
 import tarfile
@@ -10,6 +11,8 @@ import yaml
 
 from abfe.home import home
 from abfe.utils import tools
+
+logger = logging.getLogger(__name__)
 
 
 def readParmEDMolecule(top_file: tools.PathLike, gro_file: tools.PathLike) -> parmed.Structure:
@@ -655,10 +658,15 @@ def index_for_membrane_system(
         else:
             sele_SOLV += f" or resname {cofactor_name}"
 
+    logger.info("Groups in the index.ndx file:")
+    logger.info(f"\t{sele_SOLU}")
+    logger.info(f"\t{sele_MEMB}")
+    logger.info(f"\t{sele_SOLV}")
+
     sele_SOLU += ";\n"
     sele_MEMB += ";\n"
     sele_SOLV += ";\n"
-    print(sele_SOLU + sele_MEMB + sele_SOLV)
+
     with open(tmpopt.name, "w") as opt:
         opt.write(sele_SOLU + sele_MEMB + sele_SOLV)
     tools.run(f"""

--- a/src/abfe/utils/tools.py
+++ b/src/abfe/utils/tools.py
@@ -136,8 +136,7 @@ def gmx_runner(mdp: PathLike, topology: PathLike, structure: PathLike, checkpoin
 
     mdrun will update the command based on mdrun_extra. You can also suppress the use of nt and/or deffnm passing them as
     False and construct your own mdrun command:
-    e.g. gmx_runner(mdp='emin.mdp', topology='ligand.top',structure='ligand.gro',
-            deffnm = False, cpi = True, s = 'emin.tpr', o = 'emin2', c = 'emin3')
+    e.g. gmx_runner(mdp='emin.mdp', topology='ligand.top',structure='ligand.gro', deffnm = False, cpi = True, s = 'emin.tpr', o = 'emin2', c = 'emin3')
 
     The last will give:
     gmx mdrun -nt 12 -cpi -s emin.tpr -o emi666 -c emi55


### PR DESCRIPTION
Here all custom force fields are added to a directory to prepare the protein and the membrane. The path of the directory is passed to `MakeInput` class with `custom_ff_path`. Then, include statements of the type `include "charmm36-jul2022.ff/forcefield.itp"` are allowed for topology files. In addition, the user can now from the definition of the protein or the memebrane just specify the code like

```python
protein = {
  'conf': 'protein.pdb',
  'ff': {
    'code': 'user_force_field_code'
  }

}
```
Basically, what is done is:

```python
os.environ["GMXLIB"] = os.path.abspath(custom_ff_path)
```
